### PR TITLE
ci(actions): Change actions/checkout version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,19 +11,19 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout Bucket
-        uses: actions/checkout@v2
+        uses: actions/checkout@main
         with:
           fetch-depth: 2
           path: 'my_bucket'
       - name: Checkout Scoop
-        uses: actions/checkout@v2
+        uses: actions/checkout@main
         with:
           repository: ScoopInstaller/Scoop
           path: 'scoop_core'
       - name: Init and Test
         shell: powershell
         run: |
-          $env:SCOOP_HOME="$(Resolve-Path '.\scoop_core')"
+          $env:SCOOP_HOME="$(Convert-Path '.\scoop_core')"
           .\scoop_core\test\bin\init.ps1
           .\my_bucket\bin\test.ps1
   test_pwsh:
@@ -31,18 +31,18 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout Bucket
-        uses: actions/checkout@v2
+        uses: actions/checkout@main
         with:
           fetch-depth: 2
           path: 'my_bucket'
       - name: Checkout Scoop
-        uses: actions/checkout@v2
+        uses: actions/checkout@main
         with:
           repository: ScoopInstaller/Scoop
           path: 'scoop_core'
       - name: Init and Test
         shell: pwsh
         run: |
-          $env:SCOOP_HOME="$(Resolve-Path '.\scoop_core')"
+          $env:SCOOP_HOME="$(Convert-Path '.\scoop_core')"
           .\scoop_core\test\bin\init.ps1
           .\my_bucket\bin\test.ps1


### PR DESCRIPTION
Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

Relates to https://github.com/ScoopInstaller/GithubActions/issues/21

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
