### PR TITLE
(chore): Fix typo in package request template

### DIFF
--- a/.github/ISSUE_TEMPLATE/package-request.yml
+++ b/.github/ISSUE_TEMPLATE/package-request.yml
@@ -18,7 +18,7 @@ body:
       required: true
     - label: Criteria 2
       required: true
-    - label: Criteria 2
+    - label: Criteria 3
       required: true
 - type: input
   attributes:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
Fixes a typo in the placeholder for the criteria section which prevented the (unmodified) template from working properly.

```
There is a problem with this template

body[1]: options must be unique.
```

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
