### PR TITLE
set json format to keep new lines in vscode settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,6 +15,7 @@
             ]
         }
     ],
+    "json.format.keepLines": true
     "files.exclude": {
         "**/.git": true,
         "**/.svn": true,


### PR DESCRIPTION
When `json.format.keepLines` is set to false in the global VSCode settings it clashes with the .editorconfig option `insert_final_newline = true` and the line gets removed again directly after automatic insertion.
Setting `"json.format.keepLines" = "true"` in the workspace settings fixes this.