### PR TITLE
Rework README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,19 +5,36 @@
 
 Template bucket for [Scoop](https://scoop.sh), the Windows command-line installer.
 
-How do I install these manifests?
----------------------------------
+## How do I use this template?
 
-To add this bucket, run `scoop bucket add <bucketname> https://github.com/<username>/<bucketname>`. To install, do `scoop install <manifest>`.
+1. Generate your own copy of this repository with the "Use this template"
+   button.
+2. Allow all GitHub Actions:
+   - Navigate to `Settings` - `Actions` - `General` - `Actions permissions`.
+   - Select `Allow all actions and reusable workflows`.
+   - Then `Save`.
+3. Allow writing to the repository from within GitHub Actions:
+   - Navigate to `Settings` - `Actions` - `General` - `Workflow permissions`.
+   - Select `Read and write permissions`.
+   - Then `Save`.
+4. Document the bucket in `README.md`.
+5. Replace the placeholder repository string in `bin/auto-pr.ps1`.
+6. Create new manifests by copying `bucket/app-name.json.template` to
+   `bucket/<app-name>.json`.
+7. Commit and push changes.
 
-How do I contribute new manifests?
-----------------------------------
+## How do I install these manifests?
 
-To make a new manifest contribution, please read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
+After manifests have been committed and pushed, run the following:
 
-----
+```pwsh
+scoop bucket add <bucketname> https://github.com/<username>/<bucketname>
+scoop install <bucketname>/<manifestname>
+```
 
-#### To use this template
+## How do I contribute new manifests?
 
-- Modify the Readme.md and the bin/auto-pr.ps1 files accordingly.
-- Enable GitHub Actions for this repository.
+To make a new manifest contribution, please read the [Contributing
+Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)
+and [App Manifests](https://github.com/ScoopInstaller/Scoop/wiki/App-Manifests)
+wiki page.


### PR DESCRIPTION
This PR reworks the README.md file. I just used this template for my own bucket, and saw some areas that could be improved:

- Reorder the sections, putting the "How do I use this template?" first. This is the first way you'll interact with this template.
- Provide step-by-step instructions to using the template, elaborating in certain areas. Specifically, instruct how to set the GitHub Actions write permission (see #8).
- Show app installation commands in a way similar to how <https://scoop.sh> does.
- Reference the [App Manifests](https://github.com/ScoopInstaller/Scoop/wiki/App-Manifests) wiki page too, which includes detail about manifest keys.
- Use consistent markdown heading syntax (get rid of the underline style).

Closes #8

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
