### PR TITLE
Document how to get bucket indexed

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Template bucket for [Scoop](https://scoop.sh), the Windows command-line installe
 6. Create new manifests by copying `bucket/app-name.json.template` to
    `bucket/<app-name>.json`.
 7. Commit and push changes.
+8. If you'd like your bucket to be indexed on `https://scoop.sh`, add the
+   topic `scoop-bucket` to your repository.
 
 ## How do I install these manifests?
 


### PR DESCRIPTION
Add a step to the "How do I use this template" list that allows the bucket to be indexed at <https://scoop.sh> search: Add the `scoop-bucket` topic to your bucket's repository.

(As a maintainer of my own bucket generated from this template, for a while, I was confused after I was getting indexed, and then it somehow stopped. Then I stumbled upon the `scoop-bucket`-topic method in the reference below. I'm not sure what happened.)

Opting-in to indexing seems like a common enough goal. Therefore, we should document it.

Topics are not inherited from templates, so this is a step that must be done manually.

Reference: <https://github.com/ScoopInstaller/Scoop/wiki/Buckets#after-the-bucket-is-created>

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
